### PR TITLE
C4social updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
 
 
 
-FROM ruby:2.6-slim-stretch
+FROM ruby:2.4-slim-stretch
+ARG DIASPORA_VER=0.7.12.0
 
 ENV RAILS_ENV=production \
     UID=942 \
@@ -39,7 +40,6 @@ RUN apt-get update \
     wget \
     libjemalloc-dev \
     gosu \
-    libidn11-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN addgroup --GID ${GID} diaspora \
@@ -55,7 +55,7 @@ RUN mkdir -p /etc/confd/templates
 USER diaspora
 
 WORKDIR /diaspora
-RUN git clone --depth 1 https://github.com/c4social/diaspora.git diaspora
+RUN git clone --depth 1 -b v${DIASPORA_VER} https://github.com/diaspora/diaspora.git diaspora
 RUN rm -fr diaspora/.git
 RUN mv /diaspora/diaspora/* /diaspora/
 RUN mkdir /diaspora/log \
@@ -72,5 +72,5 @@ COPY --chown=root:staff config/*.toml /etc/confd/conf.d/
 # COPY --chown=diaspora:diaspora config/*.yml /diaspora/config/
 
 VOLUME /diaspora/public
-LABEL maintainer="weex"
-LABEL source="https://github.com/c4social/docker-diaspora"
+LABEL maintainer="nikkoura"
+LABEL source="https://github.com/nikkoura/docker-diaspora"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update \
 
 
 
-FROM ruby:2.4-slim-stretch
-ARG DIASPORA_VER=0.7.12.0
+FROM ruby:2.6-slim-stretch
 
 ENV RAILS_ENV=production \
     UID=942 \
@@ -40,6 +39,7 @@ RUN apt-get update \
     wget \
     libjemalloc-dev \
     gosu \
+    libidn11-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN addgroup --GID ${GID} diaspora \
@@ -55,7 +55,7 @@ RUN mkdir -p /etc/confd/templates
 USER diaspora
 
 WORKDIR /diaspora
-RUN git clone --depth 1 -b v${DIASPORA_VER} https://github.com/diaspora/diaspora.git diaspora
+RUN git clone --depth 1 https://github.com/c4social/diaspora.git diaspora
 RUN rm -fr diaspora/.git
 RUN mv /diaspora/diaspora/* /diaspora/
 RUN mkdir /diaspora/log \
@@ -72,5 +72,5 @@ COPY --chown=root:staff config/*.toml /etc/confd/conf.d/
 # COPY --chown=diaspora:diaspora config/*.yml /diaspora/config/
 
 VOLUME /diaspora/public
-LABEL maintainer="nikkoura"
-LABEL source="https://github.com/nikkoura/docker-diaspora"
+LABEL maintainer="weex"
+LABEL source="https://github.com/c4social/docker-diaspora"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   unicorn:
     container_name: diaspora_unicorn
-    image: nikkoura/diaspora:0.7.12.0
+    image: dsterry/diaspora
     command: unicorn
     restart: always
     volumes:
@@ -37,7 +37,7 @@ services:
 
   sidekiq:
     container_name: diaspora_sidekiq
-    image: nikkoura/diaspora:0.7.12.0
+    image: dsterry/diaspora
     restart: always
     command: sidekiq
     volumes:


### PR DESCRIPTION
Having had success with docker on Mastodon, I want to use docker-compose to deploy the first pod for the project as well. The forked repo is the best I found and had good documentation. This PR modifies the image it uses to pull from dsterry (my account at hub.docker.com) which should be automatically built each time I fetch the latest to weex/diaspora. Other updates are to the version of ruby used and to build off of c4social/diaspora:main.